### PR TITLE
Add copy text color function

### DIFF
--- a/Copy Text Color.sketchplugin
+++ b/Copy Text Color.sketchplugin
@@ -1,0 +1,18 @@
+// Shortcut to copy selected text's color (shift cmd x)
+
+#import '/copy_clipboard.js'
+
+// Retrieve text color and copy to clipboard
+
+if ([selection count] == 0) {
+  [doc showMessage: "Please select an element"]
+} else {
+  var layer = selection[0];
+  if (layer.textColor) {
+    var hexValue = layer.textColor().hexValue().toString();
+    clipboard.set(hexValue);
+    [doc showMessage: "Successfully copied text color hex value: " + hexValue + " to Clipboard"]
+  } else {
+    [doc showMessage:"Please select a text element"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Select a layer with fill color and press <b>Shift + Command + f</b>. The hex cod
 Select a layer with border color and press <b>Shift + Command + b</b>. The hex code should now be copied to your clipboard and ready to be pasted.
 
 <i>Note that the Shift + Command + f overwrites the Sketch default enter full screen shortcut, you can set your own shortcut by editing the plugin file to avoid conflict.<i>
+
+<b>Copy Text Color</b>
+
+Select a text object and press <b>Shift + Command + t</b>. The hex code should now be copied to your clipboard and ready to be pasted.


### PR DESCRIPTION
I really like your plugin! I wanted the ability to copy text colors too, so I figured I would add it. The key command is shift+cmd+x because, for some reason I couldn't figure out, shift+cmd+t just refused to work. AFAIK that doesn't overwrite any existing shortcuts. The code is totally based on the other two implementations.

Cheers!
M